### PR TITLE
fix: fix incorrect read of reward properties

### DIFF
--- a/src/hooks/useCreateGrant.ts
+++ b/src/hooks/useCreateGrant.ts
@@ -77,7 +77,7 @@ export default function useCreateGrant(
           };
         } else {
           reward = {
-            committed: parseAmount(data.reward, data.reward.token.decimal),
+            committed: parseAmount(data.reward, data.rewardToken.decimal),
             asset: data.rewardCurrencyAddress,
             token: data.rewardToken,
           };


### PR DESCRIPTION
This PR fixes the incorrect read of reward properties in `useCreateGrant` hook