### PR TITLE
Replaced empty emails with '-' in manage DAO tables

### DIFF
--- a/src/components/manage_dao/members.tsx
+++ b/src/components/manage_dao/members.tsx
@@ -31,7 +31,7 @@ function Members({ workspaceMembers }: Props) {
 
   const handleEmptyEmail = (email?: string) => {
     if (email) return email;
-    return '-'
+    return '-';
   }
 
   useEffect(() => {

--- a/src/components/manage_dao/members.tsx
+++ b/src/components/manage_dao/members.tsx
@@ -125,7 +125,7 @@ function Members({ workspaceMembers }: Props) {
                     textAlign="center"
                     variant="tableBody"
                   >
-                    {data.email}
+                    {data.email ? data.email : '-'}
                   </Text>
                 )}
                 <Tooltip label={data.address}>

--- a/src/components/manage_dao/members.tsx
+++ b/src/components/manage_dao/members.tsx
@@ -29,6 +29,11 @@ function Members({ workspaceMembers }: Props) {
   ];
   const tableDataFlex = [0.2622, 0.1632, 0.2448, 0.2591, 0.0734];
 
+  const handleEmptyEmail = (email?: string) => {
+    if (email) return email;
+    return '-'
+  }
+
   useEffect(() => {
     console.log(workspaceMembers);
 
@@ -125,7 +130,7 @@ function Members({ workspaceMembers }: Props) {
                     textAlign="center"
                     variant="tableBody"
                   >
-                    {data.email ? data.email : '-'}
+                    {handleEmptyEmail(data.email)}
                   </Text>
                 )}
                 <Tooltip label={data.address}>

--- a/src/components/manage_dao/members.tsx
+++ b/src/components/manage_dao/members.tsx
@@ -32,7 +32,7 @@ function Members({ workspaceMembers }: Props) {
   const handleEmptyEmail = (email?: string) => {
     if (email) return email;
     return '-';
-  }
+  };
 
   useEffect(() => {
     console.log(workspaceMembers);

--- a/src/components/manage_dao/payouts.tsx
+++ b/src/components/manage_dao/payouts.tsx
@@ -87,7 +87,7 @@ function Payouts() {
 
   const handleEmptyEmail = (email?: string) => {
     if (email) return email;
-    return '-'
+    return '-';
   }
 
   React.useEffect(() => {

--- a/src/components/manage_dao/payouts.tsx
+++ b/src/components/manage_dao/payouts.tsx
@@ -85,6 +85,11 @@ function Payouts() {
     'Actions',
   ];
 
+  const handleEmptyEmail = (email?: string) => {
+    if (email) return email;
+    return '-'
+  }
+
   React.useEffect(() => {
     if (!workspace) {
       router.push('/');
@@ -257,7 +262,7 @@ function Payouts() {
                                     </Flex>
                                   </Tooltip>
                                 ) : (
-                                  reviewer.email ? reviewer.email : '-'
+                                  handleEmptyEmail(reviewer.email)
                                 )}
                               </Text>
                               <Tooltip label={reviewer.actorId}>

--- a/src/components/manage_dao/payouts.tsx
+++ b/src/components/manage_dao/payouts.tsx
@@ -88,7 +88,7 @@ function Payouts() {
   const handleEmptyEmail = (email?: string) => {
     if (email) return email;
     return '-';
-  }
+  };
 
   React.useEffect(() => {
     if (!workspace) {

--- a/src/components/manage_dao/payouts.tsx
+++ b/src/components/manage_dao/payouts.tsx
@@ -257,7 +257,7 @@ function Payouts() {
                                     </Flex>
                                   </Tooltip>
                                 ) : (
-                                  reviewer.email
+                                  reviewer.email ? reviewer.email : '-'
                                 )}
                               </Text>
                               <Tooltip label={reviewer.actorId}>


### PR DESCRIPTION
This pull request solves the following issue:

- The email ID should be ‘-’ in the tables if not added already in manage DAO tab. 

[Reference doc](https://www.notion.so/questbook/ac72cdd7a5f04db3b2474026de226b9b?v=4a5a8cc422e1491cb5d25fd39a21f8d0&p=2ff01944e38a49619aa8ecc4512b4c3b)