### PR TITLE
fix: fixed dropdown chevron position

### DIFF
--- a/src/components/your_grants/create_grant/form/4_rewards.tsx
+++ b/src/components/your_grants/create_grant/form/4_rewards.tsx
@@ -107,7 +107,7 @@ function GrantRewardsInput({
           setSupportedCurrenciesList={setSupportedCurrenciesList}
           setIsJustAddedToken={setIsJustAddedToken}
         />
-        <Box mt={5} ml={4} minW="132px" flex={0}>
+        <Box mt={5} ml={4} minW="148px" flex={0}>
           <Dropdown
             listItemsMinWidth="132px"
             listItems={supportedCurrenciesList}


### PR DESCRIPTION
This PR solves the issue - **[Currency name is colliding with chevron](https://www.notion.so/questbook/Currency-name-is-colliding-with-chevron-53b98374a2ae491084f9560d89e4bb5b)**