### PR TITLE
fix: grants and bounties tab for reviewer

### DIFF
--- a/src/v2/components/Sidebar/Tabs.tsx
+++ b/src/v2/components/Sidebar/Tabs.tsx
@@ -123,10 +123,10 @@ function useGetTabs() {
 		} else {
 			if(applicationCount > 0) {
 				// Reviewer with applicants
-				return [ TABS.slice(0, 2), [TABS[2], TABS[7]] ]
+				return [ TABS.slice(0, 2), [TABS[2], TABS[3], TABS[7]] ]
 			} else {
 				// Reviewer without applicants
-				return [ TABS.slice(0, 1), [TABS[2], TABS[7]] ]
+				return [ TABS.slice(0, 1), [TABS[2], TABS[3], TABS[7]] ]
 			}
 		}
 	}


### PR DESCRIPTION
This PR adds the `Grants and Bounties` tab to the left sidebar for a Reviewer.