### PR TITLE
chore: added network transaction modals

### DIFF
--- a/pages/v2/your_grants/view_applicants.tsx
+++ b/pages/v2/your_grants/view_applicants.tsx
@@ -678,6 +678,7 @@ function ViewApplicants() {
 							boxShadow='inset 1px 1px 0px #F0F0F7, inset -1px -1px 0px #F0F0F7'>
 							<InReviewPanel
 								applicantsData={applicantsData}
+								grantData={grantData}
 								onSendFundsClicked={(v) => setSendFundsModalIsOpen(v)} />
 						</TabPanel>
 

--- a/src/hooks/useBatchUpdateApplicationState.ts
+++ b/src/hooks/useBatchUpdateApplicationState.ts
@@ -43,6 +43,8 @@ export default function useBatchUpdateApplicationState(
 		// targetContractABI: GrantFactoryAbi,
 	})
 
+	const [networkTransactionModalStep, setNetworkTransactionModalStep] = React.useState<number>()
+
 	useEffect(() => {
 		if(state) {
 			setError(undefined)
@@ -83,6 +85,7 @@ export default function useBatchUpdateApplicationState(
 		// }
 
 		async function validate() {
+			setNetworkTransactionModalStep(1)
 			setLoading(true)
 			// console.log('calling validate');
 			// console.log('DATA: ', data)
@@ -131,13 +134,21 @@ export default function useBatchUpdateApplicationState(
 					return
 				}
 
+				setNetworkTransactionModalStep(2)
+
 				const { txFee, receipt } = await getTransactionDetails(response, currentChainId.toString())
 
 				await chargeGas(Number(workspace?.id), Number(txFee))
 
+				setNetworkTransactionModalStep(3)
+
 				setTransactionData(receipt)
 				setLoading(false)
 				setSubmitClicked(false)
+
+				setTimeout(() => {
+					setNetworkTransactionModalStep(undefined)
+				}, 2000)
 			} catch(e: any) {
 				const message = getErrorMessage(e)
 				setError(message)
@@ -183,6 +194,8 @@ export default function useBatchUpdateApplicationState(
 				throw new Error('not connected to workspace')
 			}
 
+			setNetworkTransactionModalStep(0)
+
 			if(!currentChainId) {
 				if(switchNetwork && chainId) {
 					switchNetwork(chainId)
@@ -214,6 +227,7 @@ export default function useBatchUpdateApplicationState(
 			) {
 				return
 			}
+
 
 			validate()
 		} catch(e: any) {
@@ -256,5 +270,6 @@ export default function useBatchUpdateApplicationState(
 		getExplorerUrlForTxHash(currentChainId, transactionData?.transactionHash),
 		loading,
 		error,
+		networkTransactionModalStep
 	]
 }

--- a/src/theme/components/button.tsx
+++ b/src/theme/components/button.tsx
@@ -171,9 +171,6 @@ export default {
 				_hover: {
 					bg: 'gray.2',
 				},
-				_active: {
-					bg: 'gray.3',
-				},
 				_focus: {
 					bg: 'gray.3',
 					border: '1px solid gray.4',


### PR DESCRIPTION
This PR adds network transaction modals to the `view_applicants` page for various state transitions