### PR TITLE
chore: refactored old flows

### DIFF
--- a/src/components/explore_grants/apply_grant/form/index.tsx
+++ b/src/components/explore_grants/apply_grant/form/index.tsx
@@ -710,7 +710,7 @@ function Form({
 				}
 			</Container>
 
-			{
+			{/* {
 				acceptingApplications && (
 					<Text
 						mt={10}
@@ -744,13 +744,14 @@ function Form({
 						/>
 					</Text>
 				)
-			}
+			} */}
 
 			<Box mt={5} />
 
 			{
 				acceptingApplications && (
 					<Button
+						mt={10}
 						disabled={!isBiconomyInitialised}
 						onClick={loading ? () => {} : handleOnSubmit}
 						mx={10}

--- a/src/components/manage_dao/edit_form.tsx
+++ b/src/components/manage_dao/edit_form.tsx
@@ -595,7 +595,7 @@ function EditForm({ workspaceData }: EditFormProps) {
 					isError={hasError('telegramChannel')}
 				/>
 			</Flex>
-			<Flex
+			{/* <Flex
 				direction='row'
 				mt={4}>
 				<Text
@@ -628,7 +628,7 @@ function EditForm({ workspaceData }: EditFormProps) {
 						w='10px'
 					/>
 				</Text>
-			</Flex>
+			</Flex> */}
 
 			<Flex
 				direction='row'

--- a/src/components/signup/create_grant/form/4_rewards.tsx
+++ b/src/components/signup/create_grant/form/4_rewards.tsx
@@ -368,7 +368,7 @@ function GrantRewardsInput({
 					</Text>
 				</Flex>
 
-				<Flex
+				{/* <Flex
 					mt={8}
 					gap='2'>
 					<Flex
@@ -415,7 +415,7 @@ function GrantRewardsInput({
 							{`${shouldEncrypt ? 'YES' : 'NO'}`}
 						</Text>
 					</Flex>
-				</Flex>
+				</Flex> */}
 
 				<Flex
 					mt={8}
@@ -463,7 +463,7 @@ function GrantRewardsInput({
 					</Flex>
 				</Flex>
 
-				<Text
+				{/* <Text
 					variant='footer'
 					mt={8}
 					mb={7}
@@ -491,7 +491,7 @@ function GrantRewardsInput({
 						w='10px'
 						src='/ui_icons/link.svg'
 					/>
-				</Text>
+				</Text> */}
 			</Flex>
 
 			<Button

--- a/src/components/your_applications/grant_application/form/index.tsx
+++ b/src/components/your_applications/grant_application/form/index.tsx
@@ -715,7 +715,7 @@ function Form({
 							}
 						</Container>
 
-						{
+						{/* {
 							onEdit && (
 								<Text
 									mt={10}
@@ -753,7 +753,7 @@ function Form({
 									/>
 								</Text>
 							)
-						}
+						} */}
 
 						{
 							onEdit ? (

--- a/src/components/your_applications/manage_grant/modals/modalContentMilestoneDone.tsx
+++ b/src/components/your_applications/manage_grant/modals/modalContentMilestoneDone.tsx
@@ -90,7 +90,7 @@ function ModalContent({ milestone, onClose, chainId }: Props) {
 						maxLength={300}
 					/>
 				</Flex>
-				<Flex
+				{/* <Flex
 					direction='row'
 					w='100%'
 					align='start'
@@ -120,7 +120,7 @@ function ModalContent({ milestone, onClose, chainId }: Props) {
 							</Text>
 						</Button>
 					</Text>
-				</Flex>
+				</Flex> */}
 				<Button
 					disabled={!isBiconomyInitialised}
 					w='100%'

--- a/src/components/your_grants/create_grant/form/4_rewards.tsx
+++ b/src/components/your_grants/create_grant/form/4_rewards.tsx
@@ -179,7 +179,7 @@ function GrantRewardsInput({
 				</Text>
 			</Flex>
 
-			<Flex
+			{/* <Flex
 				mt={8}
 				gap='2'
 				justifyContent='space-between'>
@@ -202,11 +202,6 @@ function GrantRewardsInput({
 									? 'The applicant data will be visible only to DAO members.'
 									: 'The applicant data will be visible to everyone with the link.'
 							}
-							{/* <Tooltip
-                icon="/ui_icons/tooltip_questionmark.svg"
-                label="Public key linked to your wallet will allow you to see the hidden data."
-                placement="bottom-start"
-              /> */}
 						</Text>
 					</Flex>
 				</Flex>
@@ -230,7 +225,7 @@ function GrantRewardsInput({
 						{`${shouldEncrypt ? 'YES' : 'NO'}`}
 					</Text>
 				</Flex>
-			</Flex>
+			</Flex> */}
 
 			<Flex
 				mt={8}

--- a/src/components/your_grants/create_grant/form/index.tsx
+++ b/src/components/your_grants/create_grant/form/index.tsx
@@ -807,7 +807,7 @@ function Form({
 				setShouldEncryptReviews={setShouldEncryptReviews}
 			/>
 
-			<Flex
+			{/* <Flex
 				alignItems='flex-start'
 				mt={8}
 				mb={10}
@@ -841,9 +841,10 @@ function Form({
 						src='/ui_icons/link.svg'
 					/>
 				</Text>
-			</Flex>
+			</Flex> */}
 
 			<Button
+				mt={8}
 				disabled={!isBiconomyInitialised}
 				py={hasClicked ? 2 : 0}
 				onClick={hasClicked ? () => {} : handleOnSubmit}

--- a/src/components/your_grants/edit_grant/form/3_applicantDetails.tsx
+++ b/src/components/your_grants/edit_grant/form/3_applicantDetails.tsx
@@ -381,7 +381,7 @@ function ApplicantDetails({
 				)
 			}
 
-			<Flex
+			{/* <Flex
 				direction='column'
 				mt={8}>
 				<Text
@@ -621,7 +621,7 @@ function ApplicantDetails({
 						Add another criteria
 					</Text>
 				</Box>
-			</Flex>
+			</Flex> */}
 
 			{/* <Flex
 				opacity={rubricRequired ? 1 : 0.4}

--- a/src/components/your_grants/edit_grant/form/4_rewards.tsx
+++ b/src/components/your_grants/edit_grant/form/4_rewards.tsx
@@ -175,7 +175,7 @@ function GrantRewardsInput({
 				</Text>
 			</Flex>
 
-			<Flex
+			{/* <Flex
 				mt={8}
 				gap='2'
 				justifyContent='space-between'>
@@ -198,11 +198,6 @@ function GrantRewardsInput({
 									? 'The applicant data will be visible only to DAO members.'
 									: 'The applicant data will be visible to everyone with the link.'
 							}
-							{/* <Tooltip
-                icon="/ui_icons/tooltip_questionmark.svg"
-                label="Public key linked to your wallet will allow you to see the hidden data."
-                placement="bottom-start"
-              /> */}
 						</Text>
 					</Flex>
 				</Flex>
@@ -226,7 +221,7 @@ function GrantRewardsInput({
 						{`${shouldEncrypt ? 'YES' : 'NO'}`}
 					</Text>
 				</Flex>
-			</Flex>
+			</Flex> */}
 
 			<Flex
 				mt={8}

--- a/src/components/your_grants/edit_grant/form/index.tsx
+++ b/src/components/your_grants/edit_grant/form/index.tsx
@@ -720,7 +720,7 @@ function Form({
 				setShouldEncryptReviews={setShouldEncryptReviews}
 			/>
 
-			<Flex
+			{/* <Flex
 				alignItems='flex-start'
 				mt={8}
 				mb={10}
@@ -751,9 +751,10 @@ function Form({
 						src='/ui_icons/link.svg'
 					/>
 				</Text>
-			</Flex>
+			</Flex> */}
 
 			<Button
+				mt={8}
 				disabled={!isBiconomyInitialised}
 				onClick={hasClicked ? () => { } : handleOnSubmit}
 				variant='primary'>

--- a/src/components/your_grants/manage_grant/modals/modalContentMilestoneDone.tsx
+++ b/src/components/your_grants/manage_grant/modals/modalContentMilestoneDone.tsx
@@ -150,7 +150,7 @@ function ModalContent({ milestone, done }: Props) {
 						maxLength={300}
 					/>
 				</Flex>
-				<Flex
+				{/* <Flex
 					direction='row'
 					w='100%'
 					align='start'
@@ -180,7 +180,7 @@ function ModalContent({ milestone, done }: Props) {
 							</Text>
 						</Button>
 					</Text>
-				</Flex>
+				</Flex> */}
 				<Button
 					w='100%'
 					variant='primary'

--- a/src/components/your_grants/rubricDrawer.tsx
+++ b/src/components/your_grants/rubricDrawer.tsx
@@ -465,7 +465,7 @@ function RubricDrawer({
 							</Flex>
 						</Flex>
 
-						<Text
+						{/* <Text
 							variant='footer'
 							mt={8}
 							mb={7}
@@ -493,7 +493,7 @@ function RubricDrawer({
 								w='10px'
 								src='/ui_icons/link.svg'
 							/>
-						</Text>
+						</Text> */}
 
 						<Box mt={12}>
 							<Button

--- a/src/components/your_grants/yourGrantCard/index.tsx
+++ b/src/components/your_grants/yourGrantCard/index.tsx
@@ -202,8 +202,6 @@ function YourGrantCard({
 										onViewApplicantsClick={onViewApplicantsClick}
 										onEditClick={onEditClick}
 										isAdmin={isAdmin}
-										setRubricDrawerOpen={setRubricDrawerOpen}
-										initialRubricAvailable={initialRubrics?.items.length > 0 || false}
 									/>
 
 									<Box mr='1' />
@@ -326,8 +324,6 @@ function YourGrantCard({
 										onViewApplicantsClick={onViewApplicantsClick}
 										onEditClick={onEditClick}
 										isAdmin={isAdmin}
-										setRubricDrawerOpen={setRubricDrawerOpen}
-										initialRubricAvailable={initialRubrics?.items.length > 0 || false}
 									/>
 									{
 										acceptingApplications && (

--- a/src/components/your_grants/yourGrantCard/menu.tsx
+++ b/src/components/your_grants/yourGrantCard/menu.tsx
@@ -20,8 +20,6 @@ interface Props {
   onViewApplicantsClick: (() => void) | undefined
   onEditClick: (() => void) | undefined
   isAdmin: boolean
-  setRubricDrawerOpen: (arg0: boolean) => void
-  initialRubricAvailable: boolean
 }
 
 interface MenuItemProps {
@@ -41,8 +39,6 @@ function YourGrantMenu({
 	onViewApplicantsClick,
 	onEditClick,
 	isAdmin,
-	setRubricDrawerOpen,
-	initialRubricAvailable,
 }: Props) {
 	const [copied, setCopied] = React.useState(false)
 
@@ -65,15 +61,6 @@ function YourGrantMenu({
 	]
 
 	const adminItems: MenuItemProps[] = [
-		{
-			iconPath: '/ui_icons/eval_setup.svg',
-			iconWidth: '24px',
-			iconHeight: '24px',
-			text: initialRubricAvailable
-				? 'Edit evaluation score'
-				: 'Setup evaluation score',
-			onClick: () => setRubricDrawerOpen(true),
-		},
 	]
 
 	const archivedItems: MenuItemProps[] = [
@@ -81,15 +68,15 @@ function YourGrantMenu({
 			iconPath: '/ui_icons/view_applicants.svg',
 			text: numOfApplicants > 0 ? 'View applicants' : 'Edit grant',
 			onClick: () => (numOfApplicants > 0
-				? onViewApplicantsClick && onViewApplicantsClick()
-				: onEditClick && onEditClick()),
+				? onViewApplicantsClick?.()
+				: onEditClick?.()),
 		},
 	]
 	const nonArchivedItems: MenuItemProps[] = [
 		{
 			iconPath: '/ui_icons/archive_grant.svg',
 			text: 'Archive grant',
-			onClick: () => onArchiveGrantClick && onArchiveGrantClick(),
+			onClick: () => onArchiveGrantClick?.(),
 		},
 	]
 


### PR DESCRIPTION
This PR does the following:

1. Removes the option of enabling / disabling PII for a grant
2. Removes adding / editing of evaluation rubric from all flows, except from the `view_applicants` page
3. Removes all copies that said `By pressing this..... approve this transaction in your wallet`