### PR TITLE
Network modals and onboarding

### DIFF
--- a/pages/onboarding/create-domain.tsx
+++ b/pages/onboarding/create-domain.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useContext, useEffect, useRef, useState } from 'react'
 import { Box, Flex, HStack, IconButton, Image, Spacer, Text, ToastId, useToast } from '@chakra-ui/react'
+import { logger } from 'ethers'
 import { useRouter } from 'next/router'
 import { ApiClientsContext, WebwalletContext } from 'pages/_app'
 import ErrorToast from 'src/components/ui/toasts/errorToast'
@@ -223,6 +224,9 @@ const OnboardingCreateDomain = () => {
 				const workspaceId = Number(event.args[0].toBigInt())
 				// console.log('workspace_id', workspace_id)
 
+				const newWorkspace = `chain_${network}-0x${workspaceId.toString(16)}`
+				logger.info({ newWorkspace }, 'New workspace created')
+				localStorage.setItem('currentWorkspace', newWorkspace)
 				await addAuthorizedOwner(workspaceId, webwallet?.address!, scwAddress, network.toString(),
 					'this is the safe addres - to be updated in the new flow')
 				// console.log('fdsao')

--- a/pages/your_grants/index.tsx
+++ b/pages/your_grants/index.tsx
@@ -410,7 +410,7 @@ function YourGrantsAdminView({ isAdmin, isReviewer }: { isAdmin: boolean, isRevi
 				justify='center'>
 				<Flex
 					direction='column'
-					w='55%'
+					w='65%'
 					alignItems='stretch'
 					pb={8}
 					px={10}>
@@ -657,7 +657,7 @@ function YourGrantsAdminView({ isAdmin, isReviewer }: { isAdmin: boolean, isRevi
 						<AssignedGrantEmptyState />
 					}
 				</Flex>
-				<Flex
+				{/* <Flex
 					w='26%'
 					pos='sticky'
 					minH='calc(100vh - 64px)'
@@ -667,7 +667,7 @@ function YourGrantsAdminView({ isAdmin, isReviewer }: { isAdmin: boolean, isRevi
 						isReviewer={isReviewer}
 						showCreateGrantItem={!grantCount[0] && !grantCount[1]}
 					/>
-				</Flex>
+				</Flex> */}
 			</Flex>
 		</>
 	)

--- a/src/components/your_grants/create_grant/form/index.tsx
+++ b/src/components/your_grants/create_grant/form/index.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/no-shadow */
 import React, { useEffect, useState } from 'react'
 import {
-	Box, Button, Flex,
-	Image, Link, Text, } from '@chakra-ui/react'
+	Box, Button, Flex, Text } from '@chakra-ui/react'
 import {
 	Token,
 	WorkspaceUpdateRequest,
@@ -17,17 +16,13 @@ import Details from 'src/components/your_grants/create_grant/form/2_details'
 import ApplicantDetails from 'src/components/your_grants/create_grant/form/3_applicantDetails'
 import GrantRewardsInput from 'src/components/your_grants/create_grant/form/4_rewards'
 import applicantDetailsList from 'src/constants/applicantDetailsList'
-import { CHAIN_INFO } from 'src/constants/chains'
 import SAFES_ENDPOINTS_MAINNETS from 'src/constants/safesEndpoints.json'
 import SAFES_ENDPOINTS_TESTNETS from 'src/constants/safesEndpointsTest.json'
 import strings from 'src/constants/strings.json'
 import { useQuestbookAccount } from 'src/hooks/gasless/useQuestbookAccount'
 import useSubmitPublicKey from 'src/hooks/useSubmitPublicKey'
 import useUpdateWorkspacePublicKeys from 'src/hooks/useUpdateWorkspacePublicKeys'
-import useAxios from 'src/hooks/utils/useAxios'
-import useCustomToast from 'src/hooks/utils/useCustomToast'
 import { SafeToken } from 'src/types'
-import { getUrlForIPFSHash } from 'src/utils/ipfsUtils'
 import { getSupportedChainIdFromWorkspace } from 'src/utils/validationUtils'
 
 const SAFES_ENDPOINTS = { ...SAFES_ENDPOINTS_MAINNETS, ...SAFES_ENDPOINTS_TESTNETS }
@@ -112,9 +107,8 @@ function Form({
 	const [publicKey] = React.useState<WorkspaceUpdateRequest>({
 		publicKey: '',
 	})
-	const [transactionData, transactionLink, , isBiconomyInitialised] = useUpdateWorkspacePublicKeys(publicKey)
+	const [transactionData, , , isBiconomyInitialised] = useUpdateWorkspacePublicKeys(publicKey)
 
-	const { setRefresh } = useCustomToast(transactionLink)
 	const [admins, setAdmins] = React.useState<any[]>([])
 	const [maximumPoints, setMaximumPoints] = React.useState(5)
 
@@ -130,8 +124,6 @@ function Form({
 	React.useEffect(() => {
 		if(transactionData) {
 			setKeySubmitted(true)
-			// console.log('transactionData-----', transactionData)
-			setRefresh(true)
 		}
 	}, [transactionData])
 

--- a/src/v2/components/Onboarding/CreateDomain/SuccessfulDomainCreationModal.tsx
+++ b/src/v2/components/Onboarding/CreateDomain/SuccessfulDomainCreationModal.tsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import { ExternalLinkIcon } from '@chakra-ui/icons'
 import { AlertDialogOverlay, Button, Flex, Image, Link, Modal, ModalBody, ModalContent, Text } from '@chakra-ui/react'
-import NextLink from 'next/link'
 import { useRouter } from 'next/router'
 
 const SuccessfulDomainCreationModal = ({
@@ -62,28 +61,23 @@ const SuccessfulDomainCreationModal = ({
 						justify='center'
 						w='100%'
 						mt={2}>
-						<NextLink
-							href={daoLink ?? '#'}
-							passHref>
-
-							<Link isExternal>
-								<Flex>
-									<Text
-										variant='v2_body'
-										fontWeight='500'>
-										{domainName ?? 'Unknown'}
-										{' '}
-										DAO
-									</Text>
-									<ExternalLinkIcon
-										color='black.1'
-										boxSize='15px'
-										mx='2px' />
-								</Flex>
-
-							</Link>
-
-						</NextLink>
+						<Link
+							href={daoLink}
+							isExternal>
+							<Flex>
+								<Text
+									variant='v2_body'
+									fontWeight='500'>
+									{domainName ?? 'Unknown'}
+									{' '}
+									DAO
+								</Text>
+								<ExternalLinkIcon
+									color='black.1'
+									boxSize='15px'
+									mx='2px' />
+							</Flex>
+						</Link>
 						<Text
 							ml={1}
 							variant='v2_body'
@@ -116,7 +110,8 @@ const SuccessfulDomainCreationModal = ({
 							onClick={
 								() => {
 									router.push({
-										pathname: '/your_grants/',
+										pathname: '/signup',
+										query: { create_grant: true },
 									})
 								}
 							}>

--- a/src/v2/components/Sidebar/index.tsx
+++ b/src/v2/components/Sidebar/index.tsx
@@ -92,21 +92,8 @@ function Sidebar() {
 						workspaces={workspaces}
 						onWorkspaceClick={
 							(index, onComplete: () => void) => {
-								const members = workspaces[index]?.members
-								logger.info({ members }, 'Workspace members')
-								const member = workspaces[index].members.find((member) => {
-									const actorId = member?.actorId
-									const address = accountData?.address
-									logger.info({ actorId, address, isEqual: actorId === address.toLowerCase() }, 'Comparing actorId and address')
-									return member.actorId === accountData?.address?.toLowerCase()
-								})
-								logger.info({ member }, 'Member')
 								setWorkspace(workspaces[index])
-								if(member?.accessLevel === 'reviewer') {
-									router.push('/your_grants').then(onComplete)
-								} else {
-									router.push('/dashboard').then(onComplete)
-								}
+								router.push('/your_grants').then(onComplete)
 
 								const workspaceChainID = getSupportedChainIdFromWorkspace(workspaces[index])
 								if(network !== workspaceChainID) {


### PR DESCRIPTION
This PR adds network transaction modals to the following on-chain events:
1. Creating a grant
2. Editing a grant
3. Submitting an application

Also, it solves the following problems:
1. Upon successful domain creation, the user was not able to directly go to the Create grant page.
2. The user landing on a different domain, than the one they created, just after its creation.
3. Minor copy changes in the Network Transaction Modal