### PR TITLE
fix: safeAddress input flow

### DIFF
--- a/pages/onboarding/create-domain.tsx
+++ b/pages/onboarding/create-domain.tsx
@@ -133,6 +133,7 @@ const OnboardingCreateDomain = () => {
 			setIsSafeAddressVerified(true)
 			setStep(1)
 		} else {
+			setStep(0)
 			// console.log('safe address not verified!')
 			setIsSafeAddressVerified(false)
 		}


### PR DESCRIPTION
New flow:
Deleting the address would make the dropdown disappear. 
Removing one character from the address, should make the safe found dropdown disappear - Error: Invalid address.