### PR TITLE
set loading step to be done only after txn receipt is received

### DIFF
--- a/src/libraries/hooks/useFunctionCall.tsx
+++ b/src/libraries/hooks/useFunctionCall.tsx
@@ -87,8 +87,8 @@ function useFunctionCall({ chainId, contractName, setTransactionStep, setTransac
 			logger.info('Transaction sent', { tx })
 
 			if(tx) {
-				setTransactionStep?.(1)
 				const { receipt } = await getTransactionDetails(tx, chainId.toString())
+				setTransactionStep?.(1)
 				logger.info('Transaction executed. Waiting for block.', { receipt })
 				setTransactionHash?.(receipt?.transactionHash)
 				setTransactionStep?.(2)


### PR DESCRIPTION
The loader was indicating that files were being uploaded to ipfs, while it was still waiting for the transaction