### PR TITLE
fix:token fiatConversion typeError

### DIFF
--- a/src/screens/dashboard/_components/FundBuilder/ProposalDetails.tsx
+++ b/src/screens/dashboard/_components/FundBuilder/ProposalDetails.tsx
@@ -116,7 +116,7 @@ function ProposalDetails({ proposal, index, tokenInfo }: Props) {
 							mt='8px'>
 							≈
 							{' '}
-							{(amounts?.[index] / parseFloat(tokenInfo?.fiatConversion!.toString())).toFixed(2)}
+							{(amounts?.[index] / parseFloat(String(tokenInfo?.fiatConversion))).toFixed(2)}
 							{' '}
 							{tokenInfo?.tokenName}
 						</Text>


### PR DESCRIPTION
removed not null assertion and use String()

issue: payout token - typeError if fiatConversion is null 